### PR TITLE
Issue #17 bug fix

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,12 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "Examples: able_to_connect",
+            "type": "python",
+            "request": "launch",
+            "module": "examples.able_to_connect"
+        },
+        {
             "name": "Downloader Module",
             "type": "python",
             "request": "launch",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,6 +11,12 @@
             "module": "examples.able_to_connect"
         },
         {
+            "name": "Examples: several_clients",
+            "type": "python",
+            "request": "launch",
+            "module": "examples.several_clients"
+        },
+        {
             "name": "Downloader Module",
             "type": "python",
             "request": "launch",

--- a/examples/able_to_connect.py
+++ b/examples/able_to_connect.py
@@ -1,0 +1,8 @@
+from pymongo_inmemory import MongoClient
+
+
+if __name__ == '__main__':
+    with MongoClient() as client:
+        pass
+    with MongoClient() as client:
+        pass

--- a/examples/able_to_connect.py
+++ b/examples/able_to_connect.py
@@ -16,3 +16,4 @@ if __name__ == "__main__":
         inserted_id = collection.insert_one(data).inserted_id
         mongo_dump = bson.decode(client.pim_mongodump("test-db", "my-collection"))
         assert mongo_dump["some"] == "data"
+        assert mongo_dump["_id"] == inserted_id

--- a/examples/able_to_connect.py
+++ b/examples/able_to_connect.py
@@ -1,8 +1,18 @@
+import logging
+
+import bson
+
 from pymongo_inmemory import MongoClient
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
     with MongoClient() as client:
-        pass
-    with MongoClient() as client:
-        pass
+        db = client["test-db"]
+        collection = db["my-collection"]
+        data = {
+            "some": "data"
+        }
+        inserted_id = collection.insert_one(data).inserted_id
+        mongo_dump = bson.decode(client.pim_mongodump("test-db", "my-collection"))
+        assert mongo_dump["some"] == "data"

--- a/examples/several_clients.py
+++ b/examples/several_clients.py
@@ -1,0 +1,26 @@
+import logging
+
+import bson
+
+from pymongo_inmemory import MongoClient
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+    with MongoClient() as client1:
+        with MongoClient() as client2:
+            db1 = client1["test-db"]
+            db2 = client2["test-db"]
+            collection1 = db1["my-collection"]
+            collection2 = db2["my-collection"]
+            data = {
+                "some": "data"
+            }
+            inserted_id1 = collection1.insert_one(data).inserted_id
+            inserted_id2 = collection2.insert_one(data).inserted_id
+            mongo_dump1 = bson.decode(client1.pim_mongodump("test-db", "my-collection"))
+            mongo_dump2 = bson.decode(client2.pim_mongodump("test-db", "my-collection"))
+            assert mongo_dump1["some"] == "data"
+            assert mongo_dump1["_id"] == inserted_id1
+            assert mongo_dump2["some"] == "data"
+            assert mongo_dump2["_id"] == inserted_id2

--- a/pymongo_inmemory/_pim.py
+++ b/pymongo_inmemory/_pim.py
@@ -13,6 +13,9 @@ class MongoClient(pymongo.MongoClient):
         self._mongod.stop()
         super().close()
 
+    def pim_mongodump(self, *args, **kwargs):
+        return self._mongod.mongodump(*args, **kwargs)
+
 
 if __name__ == "__main__":
     import logging

--- a/pymongo_inmemory/downloader.py
+++ b/pymongo_inmemory/downloader.py
@@ -295,8 +295,6 @@ def download(opsys=None, version=None):
     )
     dst_file = os.path.join(dl_folder, downloaded_file_pattern.format(ver=version))
 
-    _mkdir_ifnot_exist("data")
-
     if (
         os.path.isfile(os.path.join(bin_folder(), "mongod")) or
         os.path.isfile(os.path.join(bin_folder(), "mongod.exe"))


### PR DESCRIPTION
Fixes #17 

Issue was originating from how we check the health status of running server. We were ignoring the connection string and querying uptime via `mongo cli` client directly, which was defaulting to port 27017 and `localhost`. So this was a very crucial bug :) 

With this PR I've also added ability to run several servers in parallel by using a temp directory for data storage. Hence if previous process has not been cleaned up for some reason (which happens a lot, if python is terminated through debugger,) a new process can still be run.

I've also added two "example code" files, which are actually handy for integration testing. I'll create a ticket for using these and few more incoming for integration testing.