### PR TITLE
Don't add signals if not in main thread

### DIFF
--- a/pymongo_inmemory/mongod.py
+++ b/pymongo_inmemory/mongod.py
@@ -9,9 +9,10 @@ import logging
 import os
 import signal
 import subprocess
+import threading
 from tempfile import TemporaryDirectory
 
-from ._utils import find_open_port, conf
+from ._utils import conf, find_open_port
 from .downloader import bin_folder, download
 
 logger = logging.getLogger("PYMONGOIM_MONGOD")
@@ -34,7 +35,12 @@ def clean_before_kill(signum, stack):
     exit()
 
 
-signal.signal(signal.SIGTERM, clean_before_kill)
+# as per https://docs.python.org/3.6/library/signal.html#signals-and-threads
+# only the main thread is allowed to set a new signal handler.
+# This means that if this module is imported by a thread other than the
+# main one it will raise an error.
+if threading.current_thread() is threading.main_thread():
+    signal.signal(signal.SIGTERM, clean_before_kill)
 
 
 class MongodConfig:

--- a/tests/unit/test_async.py
+++ b/tests/unit/test_async.py
@@ -1,0 +1,19 @@
+import asyncio
+import threading
+import sys
+
+def test_init_module_in_loop():
+    sys.modules.pop('pymongo_inmemory.mongod', None)
+
+    async def main():
+        import pymongo_inmemory.mongod
+        return True
+
+    loop = asyncio.new_event_loop()
+    thread = threading.Thread(target=loop.run_forever, daemon=True)
+    thread.start()
+    result = asyncio.run_coroutine_threadsafe(main(), loop).result()
+    loop.call_soon_threadsafe(loop.stop)
+    thread.join()
+
+    assert result


### PR DESCRIPTION
Been having some trouble when including the module from threads other than the main one. I believe this change does not impact any current usage, can you take a look?