### PR TITLE
Remove extraneous bin folder mechanism, use extracted bin folder

### DIFF
--- a/pymongo_inmemory/__init__.py
+++ b/pymongo_inmemory/__init__.py
@@ -1,9 +1,8 @@
 from ._pim import MongoClient
 from .mongod import Mongod
-from .downloader import bin_folder, download
+from .downloader import download
 
 __all__ = [
-    "bin_folder",
     "download",
     "MongoClient",
     "Mongod",

--- a/pymongo_inmemory/_utils.py
+++ b/pymongo_inmemory/_utils.py
@@ -2,7 +2,6 @@ from configparser import ConfigParser
 from collections import namedtuple
 import logging
 import os
-import platform
 import socket
 
 

--- a/pymongo_inmemory/_utils.py
+++ b/pymongo_inmemory/_utils.py
@@ -99,7 +99,3 @@ def conf(option, fallback=None, optional=True):
     logger.debug("Value for {}=={}".format(option, value))
 
     return value
-
-
-def is_windows():
-    return platform.system() == "Windows"

--- a/pymongo_inmemory/_utils.py
+++ b/pymongo_inmemory/_utils.py
@@ -2,6 +2,7 @@ from configparser import ConfigParser
 from collections import namedtuple
 import logging
 import os
+import platform
 import socket
 
 
@@ -98,3 +99,7 @@ def conf(option, fallback=None, optional=True):
     logger.debug("Value for {}=={}".format(option, value))
 
     return value
+
+
+def is_windows():
+    return platform.system() == "Windows"

--- a/pymongo_inmemory/mongod.py
+++ b/pymongo_inmemory/mongod.py
@@ -9,11 +9,12 @@ import logging
 import os
 import signal
 import subprocess
+import time
 import threading
 from tempfile import TemporaryDirectory
 
 from ._utils import conf, find_open_port
-from .downloader import bin_folder, download
+from .downloader import download
 
 logger = logging.getLogger("PYMONGOIM_MONGOD")
 # Holds references to open Popen objects which spawn MongoDB daemons.
@@ -68,9 +69,8 @@ class Mongod:
     """
     def __init__(self):
         logger.info("Checking binary")
-        download()
 
-        self._bin_folder = bin_folder()
+        self._bin_folder = download()
         self._proc = None
         self._mongod_port = None
         self._mongod_ip = None
@@ -117,6 +117,9 @@ class Mongod:
     def stop(self):
         logger.info("Sending kill signal to mongod.")
         self._proc.terminate()
+        while self._proc.poll() is None:
+            logger.debug("Waiting for MongoD shutdown.")
+            time.sleep(1)
         self.data_folder.cleanup()
 
     @property

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pymongo_inmemory"
-version = "0.2.2"
+version = "0.2.3"
 description = "A mongo mocking library with an ephemeral MongoDB running in memory."
 authors = [
     "Kaizen Dorks <kaizendorks@gmail.com>",

--- a/tests/functional/test_downloader.py
+++ b/tests/functional/test_downloader.py
@@ -1,9 +1,7 @@
 import os
 import shutil
-import stat
 import tarfile
 import urllib.request as request
-import warnings
 
 import pytest
 

--- a/tests/functional/test_downloader.py
+++ b/tests/functional/test_downloader.py
@@ -8,7 +8,6 @@ import warnings
 import pytest
 
 from pymongo_inmemory import downloader
-from pymongo_inmemory._utils import is_windows
 
 
 @pytest.fixture
@@ -49,11 +48,3 @@ def test_downloader(make_mongo_payload, urlretrieve_patcher, monkeypatch, tmpdir
     bin_dir = downloader.download(os_name="osx", os_ver="generic", version="4.0.1")
     expected_mongod_path = os.path.join(bin_dir, "mongod")
     assert os.path.isfile(expected_mongod_path)
-
-    # chmod can only create read-only files on windows,
-    # so this assertion fails even though code is doing its job
-    if is_windows():
-        warnings.warn("Skipping file permission assertion on Windows")
-    else:
-        st = os.stat(expected_mongod_path)
-        assert stat.filemode(st.st_mode) == "-r-xr-xr-x"

--- a/tests/functional/test_downloader.py
+++ b/tests/functional/test_downloader.py
@@ -1,7 +1,6 @@
 import os
 import shutil
 import stat
-import sys
 import tarfile
 import urllib.request as request
 import warnings
@@ -9,6 +8,7 @@ import warnings
 import pytest
 
 from pymongo_inmemory import downloader
+from pymongo_inmemory._utils import is_windows
 
 
 @pytest.fixture
@@ -46,13 +46,13 @@ def test_downloader(make_mongo_payload, urlretrieve_patcher, monkeypatch, tmpdir
     urlretrieve = urlretrieve_patcher(tmpdir / "test_archive.tar")
     monkeypatch.setattr(request, "urlretrieve", urlretrieve)
 
-    downloader.download(os_name="osx", os_ver="generic", version="4.0.1")
-    expected_mongod_path = tmpdir / ".cache" / "bin" / "mongod"
+    bin_dir = downloader.download(os_name="osx", os_ver="generic", version="4.0.1")
+    expected_mongod_path = os.path.join(bin_dir, "mongod")
     assert os.path.isfile(expected_mongod_path)
 
     # chmod can only create read-only files on windows,
     # so this assertion fails even though code is doing its job
-    if sys.platform.startswith("win"):
+    if is_windows():
         warnings.warn("Skipping file permission assertion on Windows")
     else:
         st = os.stat(expected_mongod_path)

--- a/tests/unit/test_downloader_functions.py
+++ b/tests/unit/test_downloader_functions.py
@@ -15,20 +15,6 @@ def test_env_folders_overwrite_default_extractfolder(monkeypatch):
     assert downloader._extract_folder() == "test_folder"
 
 
-def test_env_folders_overwrite_default_binfolder(monkeypatch):
-    monkeypatch.setenv("PYMONGOIM__BIN_FOLDER", "test_folder")
-    assert downloader.bin_folder() == "test_folder"
-
-
-def test_default_bin_folder(monkeypatch, tmpdir):
-    monkeypatch.setattr(downloader, "CACHE_FOLDER", tmpdir)
-    assert path.samefile(
-        downloader.bin_folder(),
-        path.join(tmpdir, "bin")
-    )
-    assert path.exists(path.join(tmpdir, "bin"))
-
-
 def test_default_dl_folder(monkeypatch, tmpdir):
     monkeypatch.setattr(downloader, "CACHE_FOLDER", tmpdir)
     assert path.samefile(


### PR DESCRIPTION
Closes #41
Closes #10 

I realised that the bin folder mechanism was unnecesessarily complex and lead to file permissions errors while copying and pasting extracted binary contents. I don't exactly remember why it was necessary in the first place. In any case there is no reason not to use the extracted bin folder. This got rid of Windows file permissions errors and need to check file permissions in the tests.

On the way I also realised that, after `subprocess` module sends a termination signal, it takes time for MongoD to shutdown. So now, exit process properly wait until the server is down.