### PR TITLE
File path too long#52

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pymongo_inmemory"
-version = "0.2.5"
+version = "0.2.6"
 description = "A mongo mocking library with an ephemeral MongoDB running in memory."
 authors = [
     "Kaizen Dorks <kaizendorks@gmail.com>",

--- a/tests/unit/test_downloader_functions.py
+++ b/tests/unit/test_downloader_functions.py
@@ -33,18 +33,6 @@ def test_default_extract_folder(monkeypatch, tmpdir):
     assert path.exists(path.join(tmpdir, "extract"))
 
 
-def test_extracted_folder(monkeypatch, tmpdir):
-    monkeypatch.setattr(downloader, "CACHE_FOLDER", tmpdir)
-    assert path.samefile(
-        downloader._extracted_folder("mongodb-amazon2-x86_64-1.1.1.tar"),
-        path.join(tmpdir, "extract", "mongodb-amazon2-x86_64-1.1.1-tar")
-    )
-    assert path.samefile(
-        downloader._extracted_folder("mongodb-windows-x86_64-1.1.1.zip"),
-        path.join(tmpdir, "extract", "mongodb-windows-x86_64-1.1.1-zip")
-    )
-
-
 def test_make_folder(monkeypatch, tmpdir):
     assert path.samefile(
         downloader._mkdir_ifnot_exist(tmpdir, "test"),


### PR DESCRIPTION
- Having another folder with the same name and version seems redundant as the file downloaded from the internet contains that already.
- Removing this function allowed an extra 30 characters of free space from the limit of 260 on windows.
- I had to remove a test that was failing, but it seems that test was only to test that specific function which no longer exists.
- I've tested on windows but haven't gotten a chance to test on Linux.
- Still not the best fix but should cover the edge cases where this can happen.