### PR TITLE
Allow use of local mongod

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ with MongoClient() as client:
 | `os_version`       | If an operating system has several versions use this parameter to select one | Yes       | Latest versoin of the OS will be selected from the list |
 | `download_url`     | If set, it won't attempt to determine which MongoDB to download. However there won't be a fallback either.| Yes       | Automatically determined from given parameters and using [internal URL bank](pymongo_inmemory/downloader/_patterns.py)**|
 | `ignore_cache`     | Even if there is a downloaded version in the cache, download it again. | Yes       | False               |
+| `use_local_mongod` | If set, it will try to use a local mongod instance instead of downloading one. | Yes     | False               |
 ||||
 
 * ****Note 1:*** Generic Linux version offering for MongoDB ends with version **4.0.23**. If the operating system is just `linux` and if selected MongoDB version is higher, it will default to `4.0.23`.

--- a/pymongo_inmemory/mongod.py
+++ b/pymongo_inmemory/mongod.py
@@ -88,7 +88,7 @@ class Mongod:
         logger.info("Checking binary")
 
         print(not conf('use_local_mongod', False))
-        self._bin_folder = download() if not conf('use_local_mongod', False) else ''
+        self._bin_folder = download() if not bool(conf('use_local_mongod', False)) else ''
         self._proc = None
         self._connection_string = None
 

--- a/pymongo_inmemory/mongod.py
+++ b/pymongo_inmemory/mongod.py
@@ -87,7 +87,7 @@ class Mongod:
     def __init__(self):
         logger.info("Checking binary")
 
-        self._bin_folder = download() if conf('use_local_mongod') else ''
+        self._bin_folder = download() if not conf('use_local_mongod') else ''
         self._proc = None
         self._connection_string = None
 

--- a/pymongo_inmemory/mongod.py
+++ b/pymongo_inmemory/mongod.py
@@ -87,7 +87,7 @@ class Mongod:
     def __init__(self):
         logger.info("Checking binary")
 
-        self._bin_folder = download() if conf('use_local_mongod') is None else ''
+        self._bin_folder = download() if conf('use_local_mongod') else ''
         self._proc = None
         self._connection_string = None
 

--- a/pymongo_inmemory/mongod.py
+++ b/pymongo_inmemory/mongod.py
@@ -87,7 +87,7 @@ class Mongod:
     def __init__(self):
         logger.info("Checking binary")
 
-        self._bin_folder = download() if not conf('use_local_mongod') else ''
+        self._bin_folder = download() if not conf('use_local_mongod', False) else ''
         self._proc = None
         self._connection_string = None
 

--- a/pymongo_inmemory/mongod.py
+++ b/pymongo_inmemory/mongod.py
@@ -87,7 +87,7 @@ class Mongod:
     def __init__(self):
         logger.info("Checking binary")
 
-        self._bin_folder = download()
+        self._bin_folder = download() if conf('use_local_mongod') is None else ''
         self._proc = None
         self._connection_string = None
 

--- a/pymongo_inmemory/mongod.py
+++ b/pymongo_inmemory/mongod.py
@@ -87,7 +87,6 @@ class Mongod:
     def __init__(self):
         logger.info("Checking binary")
 
-        print(not conf('use_local_mongod', False))
         self._bin_folder = '' if conf('use_local_mongod') == 'True' else download()
         self._proc = None
         self._connection_string = None

--- a/pymongo_inmemory/mongod.py
+++ b/pymongo_inmemory/mongod.py
@@ -87,6 +87,7 @@ class Mongod:
     def __init__(self):
         logger.info("Checking binary")
 
+        print(not conf('use_local_mongod', False))
         self._bin_folder = download() if not conf('use_local_mongod', False) else ''
         self._proc = None
         self._connection_string = None

--- a/pymongo_inmemory/mongod.py
+++ b/pymongo_inmemory/mongod.py
@@ -88,7 +88,7 @@ class Mongod:
         logger.info("Checking binary")
 
         print(not conf('use_local_mongod', False))
-        self._bin_folder = download() if not bool(conf('use_local_mongod', False)) else ''
+        self._bin_folder = '' if conf('use_local_mongod') == 'True' else download()
         self._proc = None
         self._connection_string = None
 


### PR DESCRIPTION
First off, wanted to say love the project :)

I'm currently developing on arch linux, meaning the highest possible version for me to use right now is mongod 4.0, however, I have mongod 6.0 running locally, when I just put "mongod" in my command line.

This basically just adds a configuration parameter than when set to true (defaulting to false), runs just "mongod" in the command line instead of downloading it and using that ones location.