### PR TITLE
Make storage engine configurable

### DIFF
--- a/pymongo_inmemory/context.py
+++ b/pymongo_inmemory/context.py
@@ -127,7 +127,7 @@ class Context:
         )
         self.archive_folder = mkdir_ifnot_exist(self.download_folder, self.url_hash)
         self.extracted_folder = mkdir_ifnot_exist(self.extract_folder, self.url_hash)
-        self.storage_engine = "inMemory"
+        self.storage_engine = "ephemeralForTest"
 
     def __str__(self):
         return (

--- a/pymongo_inmemory/context.py
+++ b/pymongo_inmemory/context.py
@@ -127,6 +127,7 @@ class Context:
         )
         self.archive_folder = mkdir_ifnot_exist(self.download_folder, self.url_hash)
         self.extracted_folder = mkdir_ifnot_exist(self.extract_folder, self.url_hash)
+        self.storage_engine = "ephemeralForTest"
 
     def __str__(self):
         return (
@@ -143,6 +144,7 @@ class Context:
             f"Use Local MongoD {self.use_local_mongod}\n"
             f"Download Folder {self.download_folder}\n"
             f"Extract Folder {self.extract_folder}\n"
+            f"Storage engine {self.storage_engine}\n"
         )
 
     def _build_operating_system_info(self, os_name=None):

--- a/pymongo_inmemory/context.py
+++ b/pymongo_inmemory/context.py
@@ -154,14 +154,6 @@ class Context:
             os_name = _mapping.get(platform.system())
             if os_name is None:
                 raise OperatingSystemNotFound("Can't determine operating system.")
-            else:
-                if os_name == "linux":
-                    logger.warning(
-                        (
-                            "Starting from MongoDB 4.0.23 "
-                            "there isn't a generic Linux version of MongoDB"
-                        )
-                    )
         return os_name
 
     def _build_download_url(self):

--- a/pymongo_inmemory/context.py
+++ b/pymongo_inmemory/context.py
@@ -127,7 +127,7 @@ class Context:
         )
         self.archive_folder = mkdir_ifnot_exist(self.download_folder, self.url_hash)
         self.extracted_folder = mkdir_ifnot_exist(self.extract_folder, self.url_hash)
-        self.storage_engine = "ephemeralForTest"
+        self.storage_engine = "inMemory"
 
     def __str__(self):
         return (

--- a/pymongo_inmemory/mongod.py
+++ b/pymongo_inmemory/mongod.py
@@ -51,7 +51,7 @@ class MongodConfig:
     def __init__(self, pim_context: Context):
         self._pim_context = pim_context
         self.local_address = "127.0.0.1"
-        self.engine = "ephemeralForTest"
+        self.engine = pim_context.storage_engine
 
     @property
     def port(self):

--- a/pymongo_inmemory/mongod.py
+++ b/pymongo_inmemory/mongod.py
@@ -135,9 +135,10 @@ class Mongod:
             self.config.port,
             "--bind_ip",
             self.config.local_address,
-            "--storageEngine",
-            self.config.engine,
         ]
+        if self.config.engine is not None:
+            boot_command.append("--storageEngine")
+            boot_command.append(self.config.engine)
         logger.debug(boot_command)
         self._proc = subprocess.Popen(boot_command)
         _popen_objs.append(self._proc)


### PR DESCRIPTION
In mongodb v7 the ephemeral storage engine is not supported anymore. I made it configurable, so it can be disabled.