### PR TITLE
The storage_engine was not actually a configurable parameter

### DIFF
--- a/pymongo_inmemory/context.py
+++ b/pymongo_inmemory/context.py
@@ -127,7 +127,7 @@ class Context:
         )
         self.archive_folder = mkdir_ifnot_exist(self.download_folder, self.url_hash)
         self.extracted_folder = mkdir_ifnot_exist(self.extract_folder, self.url_hash)
-        self.storage_engine = "ephemeralForTest"
+        self.storage_engine = conf("storage_engine", "ephemeralForTest")
 
     def __str__(self):
         return (


### PR DESCRIPTION
without getting the parameter from the different configuration options, the value is actually hardcoded and cannot be changed by the user.