### PR TITLE
Fix issue #98 - Crash when using the mongod_port parameter 

### DIFF
--- a/pymongo_inmemory/mongod.py
+++ b/pymongo_inmemory/mongod.py
@@ -59,7 +59,7 @@ class MongodConfig:
         if set_port is None:
             return str(find_open_port(range(27017, 28000)))
         else:
-            return set_port
+            return str(set_port)
 
     @property
     def connection_string(self):


### PR DESCRIPTION
This PR fixes issue https://github.com/kaizendorks/pymongo_inmemory/issues/98
When when using the `mongod_port` parameter the library code crashes with the following exception:

```
  File "/.../lib/python3.12/site-packages/pymongo_inmemory/mongod.py", line 143, in start
    self._proc = subprocess.Popen(boot_command)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/.../lib/python3.12/subprocess.py", line 1026, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/.../lib/python3.12/subprocess.py", line 1883, in _execute_child
    self.pid = _fork_exec(
               ^^^^^^^^^^^
TypeError: expected str, bytes or os.PathLike object, not int

``` 

The cause of the error is that the `subprocess.Popen` method does not accept int arguments, while the `mongod_port` parameter is forced as integer. 

The mongod port value is set as str in all cases, except when passed as a customer parameter.
The proposed code change fixes this case.