### PR TITLE
Fix tarfile deprecation warnings

### DIFF
--- a/pymongo_inmemory/downloader/__init__.py
+++ b/pymongo_inmemory/downloader/__init__.py
@@ -81,7 +81,7 @@ def _extract_tar(tar_file, extracted_folder):
         logger.info("Starting extraction.")
         for f in t.getnames():
             logger.debug("Extracting {} to {}".format(f, extracted_folder))
-            t.extract(f, extracted_folder)
+            t.extract(f, extracted_folder, filter="data")
             logger.debug("Done extracting {}".format(f))
         logger.info("Extractiong finished.")
 


### PR DESCRIPTION
When using Python 3.12 or 3.13, `tarfile` issues a deprecation warning when extracting the downloaded copy of mongo because the extraction warning arg is omitted. See the [tarfile docs](https://docs.python.org/3/library/tarfile.html#tarfile.TarFile.extraction_filter) for more details.

This PR sets the value to `"data"`, which will be the default in Python 3.14.

Resolves #125 