### PR TITLE
Clean up temp file

### DIFF
--- a/pymongo_inmemory/downloader/__init__.py
+++ b/pymongo_inmemory/downloader/__init__.py
@@ -1,7 +1,7 @@
 import glob
 import zipfile
 import logging
-from os import path
+from os import path, unlink
 import shutil
 import tarfile
 import tempfile
@@ -52,6 +52,8 @@ def _download_file(dl_url, destination_file):
         try:
             request.urlretrieve(dl_url, filename=temp.name, reporthook=_dl_reporter)
         except HTTPError:
+            f.close()
+            unlink(f.name)
             raise CantDownload(
                 (
                     "Can't download {url}, "
@@ -59,6 +61,10 @@ def _download_file(dl_url, destination_file):
                     "Possibly the version is not provided for the operating system."
                 ).format(url=dl_url)
             )
+        except Exception:
+            f.close()
+            unlink(f.name)
+            raise
 
         logger.debug("Finished download.")
         shutil.copyfile(temp.name, destination_file)

--- a/pymongo_inmemory/downloader/__init__.py
+++ b/pymongo_inmemory/downloader/__init__.py
@@ -47,13 +47,11 @@ def _download_file(dl_url, destination_file):
         )
         return
 
-    with tempfile.NamedTemporaryFile(delete=False) as temp:
+    with tempfile.NamedTemporaryFile(delete=True) as temp:
         logger.debug("Starting download to temporary location {}".format(temp.name))
         try:
             request.urlretrieve(dl_url, filename=temp.name, reporthook=_dl_reporter)
         except HTTPError:
-            f.close()
-            unlink(f.name)
             raise CantDownload(
                 (
                     "Can't download {url}, "
@@ -61,10 +59,6 @@ def _download_file(dl_url, destination_file):
                     "Possibly the version is not provided for the operating system."
                 ).format(url=dl_url)
             )
-        except Exception:
-            f.close()
-            unlink(f.name)
-            raise
 
         logger.debug("Finished download.")
         shutil.copyfile(temp.name, destination_file)

--- a/pymongo_inmemory/downloader/__init__.py
+++ b/pymongo_inmemory/downloader/__init__.py
@@ -1,7 +1,7 @@
 import glob
 import zipfile
 import logging
-from os import path, unlink
+from os import path
 import shutil
 import tarfile
 import tempfile


### PR DESCRIPTION
It's quite annoying when it not just fails with `No space left on device` but also doesn't clean it up after a failure.

It'd be much better to move a file to desired destination after downloading it, thus avoiding extra disk writes when temporary file is placed on the same disk. But this quick fix still makes it much better.
